### PR TITLE
updated requires to reflect functional changes in package

### DIFF
--- a/codegpt.el
+++ b/codegpt.el
@@ -32,7 +32,6 @@
 ;;; Code:
 
 (require 'openai)
-(require 'openai-completions)
 
 (defgroup codegpt nil
   "Use GPT-3 tp help you write code."

--- a/codegpt.el
+++ b/codegpt.el
@@ -32,7 +32,7 @@
 ;;; Code:
 
 (require 'openai)
-(require 'openai-completions)
+(require 'openai-completion)
 
 (defgroup codegpt nil
   "Use GPT-3 tp help you write code."

--- a/codegpt.el
+++ b/codegpt.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (require 'openai)
+(require 'openai-completions)
 
 (defgroup codegpt nil
   "Use GPT-3 tp help you write code."

--- a/codegpt.el
+++ b/codegpt.el
@@ -31,7 +31,7 @@
 
 ;;; Code:
 
-(require 'openai-completion)
+(require 'openai)
 
 (defgroup codegpt nil
   "Use GPT-3 tp help you write code."
@@ -84,8 +84,8 @@ boundaries of that region in buffer."
        (lambda (data)
          (openai--with-buffer codegpt-buffer-name
            (openai--pop-to-buffer codegpt-buffer-name)
-           (let* ((choices (openai-completion--data-choices data))
-                  (result (openai-completion--get-choice choices))
+           (let* ((choices (openai--data-choices data))
+                  (result (openai--get-choice choices))
                   (original-point (point)))
              (insert (string-trim result) "\n")
              (fill-region original-point (point))))


### PR DESCRIPTION
    it looks like the openai-completion--data-choices and
    openai-completion--get-choices functions were renamed to
    openai--data-choices and openai--get-choices in the openai package. I also
    changed the require to openai vs openai-collections as that is the full
    package name. addresses #5.